### PR TITLE
Pass phone number to /call API for outbound calls

### DIFF
--- a/src/app/acs/caller.py
+++ b/src/app/acs/caller.py
@@ -16,23 +16,22 @@ from azure.communication.callautomation import (
     FileSource,
     TextSource)
 import json
+from aiohttp import web
 import requests
 
 class OutboundCall:
-    target_number: str
     source_number: str
     acs_connection_string: str
     acs_callback_path: str
 
-    def __init__(self, target_number: str, source_number:str, acs_connection_string: str, acs_callback_path: str):
-        self.target_number = target_number
+    def __init__(self, source_number:str, acs_connection_string: str, acs_callback_path: str):
         self.source_number = source_number
         self.acs_connection_string = acs_connection_string
         self.acs_callback_path = acs_callback_path
     
-    async def call(self):
+    async def call(self, target_number: str):
         self.call_automation_client = CallAutomationClient.from_connection_string(self.acs_connection_string)
-        self.target_participant = PhoneNumberIdentifier(self.target_number)
+        self.target_participant = PhoneNumberIdentifier(target_number)
         self.source_caller = PhoneNumberIdentifier(self.source_number)
         call_connection_properties = self.call_automation_client.create_call(self.target_participant, 
                                                                     self.acs_callback_path,
@@ -51,6 +50,8 @@ class OutboundCall:
             if event.type == "Microsoft.Communication.CallConnected":
                 print("Call connected")
                 print(call_connection_id)
+
+        return web.Response(status=200)
 
 
     def attach_to_app(self, app, path):

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -53,12 +53,10 @@ async def create_app():
 
     rtmt = RTMiddleTier(llm_endpoint, llm_deployment, llm_credential)
 
-    if (os.environ.get("ACS_TARGET_NUMBER") is not None and
-            os.environ.get("ACS_SOURCE_NUMBER") is not None and
+    if (os.environ.get("ACS_SOURCE_NUMBER") is not None and
             os.environ.get("ACS_CONNECTION_STRING") is not None and
             os.environ.get("ACS_CALLBACK_PATH") is not None):
         caller = OutboundCall(
-            os.environ.get("ACS_TARGET_NUMBER"),
             os.environ.get("ACS_SOURCE_NUMBER"),
             os.environ.get("ACS_CONNECTION_STRING"),
             os.environ.get("ACS_CALLBACK_PATH"),
@@ -117,8 +115,10 @@ async def create_app():
         return web.FileResponse(static_directory / 'index.html')
 
     async def call(request):
+        body = await request.json()
+
         if (caller is not None):
-            await caller.call()
+            await caller.call(body['number'])
             return web.Response(text="Created outbound call")
         else:
             return web.Response(text="Outbound calling is not configured")

--- a/src/app/static/app.js
+++ b/src/app/static/app.js
@@ -139,18 +139,16 @@ function onToggleListening() {
 
 function onCallButton() {
     const phonenumber = document.getElementById('phonenumber').value;
-
-    const callDetails = {
-        number: phonenumber
-    };
-
-
-    theUrl = window.location.href + "call";
-    var xmlHttp = new XMLHttpRequest();
-    xmlHttp.open( "POST", theUrl, false );
-    xmlHttp.send( callDetails );
     
-    reportDiv.textContent = xmlHttp.responseText;   
+    theUrl = window.location.href + "call";
+    fetch(theUrl, {
+        method : "POST",
+        body : JSON.stringify({
+            number: phonenumber
+        })
+    })
+    .then(response => reportDiv.textContent = response.json())
+    .catch(error => console.error('Error:', error));
 }
 
 toggleButton.addEventListener('click', onToggleListening);


### PR DESCRIPTION
The phone number, that ACS should call has been "hardcoded" in the backend (with env vars), although there was the option in the frontend, to provide it manually. I removed the static target number and included the user-provided one from the frontend.

Backend changes:

* [`src/app/acs/caller.py`](diffhunk://#diff-f054f11fac94f21758c9faa186cacefe6851597a73651e073c8851aab915cd56R19-R34): Removed the `target_number` attribute from the `OutboundCall` class and updated the `call` method to accept `target_number` as a parameter.
* [`src/app/acs/caller.py`](diffhunk://#diff-f054f11fac94f21758c9faa186cacefe6851597a73651e073c8851aab915cd56R54-R55): Added a return statement to provide a 200 HTTP status response in the `_outbound_call_handler` method, which otherwise caused an error with ACS, when there is no HTTP response returned
* [`src/app/app.py`](diffhunk://#diff-5307f51f1d573ebe550ceb1d91263a76adb245a88afb1bd2dbe7c0d65217b26bL56-L61): Removed the `ACS_TARGET_NUMBER` environment variable check and updated the `create_app` function to reflect this change.
* [`src/app/app.py`](diffhunk://#diff-5307f51f1d573ebe550ceb1d91263a76adb245a88afb1bd2dbe7c0d65217b26bR118-R121): Updated the `call` function to read the target number from the request body JSON and pass it to the `caller.call` method.

Frontend changes:

* [`src/app/static/app.js`](diffhunk://#diff-7aeae2b87119c15f0bf339a10de9e2226f92c703a3c88f7c233532d7e39800e7L143-R151): Refactored the `onCallButton` function to use the Fetch API for making POST requests and handling responses, replacing the previous legacy XMLHttpRequest implementation.