### PR TITLE
Add Phone Call Support via ACS

### DIFF
--- a/src/app/acs/caller.py
+++ b/src/app/acs/caller.py
@@ -20,13 +20,8 @@ from azure.communication.callautomation import (
     DtmfTone,
     VoiceKind,
     FileSource,
-    TextSource,
-    MediaStreamingOptions,
-    AudioFormat,
-    MediaStreamingTransportType,
-    MediaStreamingContentType,
-    MediaStreamingAudioChannelType,
-    PhoneNumberIdentifier)
+    TextSource
+)
 from azure.communication.callautomation.aio import CallAutomationClient
 from azure.communication.phonenumbers import PhoneNumbersClient,PhoneNumberCapabilityType, PhoneNumberAssignmentType, PhoneNumberType, PhoneNumberCapabilities
 import json

--- a/src/app/acs/caller.py
+++ b/src/app/acs/caller.py
@@ -16,23 +16,22 @@ from azure.communication.callautomation import (
     FileSource,
     TextSource)
 import json
+from aiohttp import web
 import requests
 
 class OutboundCall:
-    target_number: str
     source_number: str
     acs_connection_string: str
     acs_callback_path: str
 
-    def __init__(self, target_number: str, source_number:str, acs_connection_string: str, acs_callback_path: str):
-        self.target_number = target_number
+    def __init__(self, source_number:str, acs_connection_string: str, acs_callback_path: str):
         self.source_number = source_number
         self.acs_connection_string = acs_connection_string
         self.acs_callback_path = acs_callback_path
     
-    async def call(self):
+    async def call(self, target_number: str):
         self.call_automation_client = CallAutomationClient.from_connection_string(self.acs_connection_string)
-        self.target_participant = PhoneNumberIdentifier(self.target_number)
+        self.target_participant = PhoneNumberIdentifier(target_number)
         self.source_caller = PhoneNumberIdentifier(self.source_number)
         call_connection_properties = self.call_automation_client.create_call(self.target_participant, 
                                                                     self.acs_callback_path,
@@ -51,6 +50,8 @@ class OutboundCall:
             if event.type == "Microsoft.Communication.CallConnected":
                 print("Call connected")
                 print(call_connection_id)
+
+        return web.Response(status=200)
 
 
     def attach_to_app(self, app, path):

--- a/src/app/acs/caller.py
+++ b/src/app/acs/caller.py
@@ -7,10 +7,15 @@ from azure.communication.callautomation import (
     CallAutomationClient,
     CallConnectionClient,
     PhoneNumberIdentifier,
+    MediaStreamingOptions,
+    MediaStreamingTransportType,
+    MediaStreamingContentType,
     RecognizeInputType,
     MicrosoftTeamsUserIdentifier,
+    MediaStreamingAudioChannelType,
     CallInvite,
     RecognitionChoice,
+    AudioFormat,
     DtmfTone,
     VoiceKind,
     FileSource,
@@ -23,19 +28,32 @@ class OutboundCall:
     source_number: str
     acs_connection_string: str
     acs_callback_path: str
+    media_streaming_configuration: MediaStreamingOptions
 
-    def __init__(self, source_number:str, acs_connection_string: str, acs_callback_path: str):
+    def __init__(self, source_number:str, acs_connection_string: str, acs_callback_path: str, acs_media_streaming_websocker_path: str):
         self.source_number = source_number
         self.acs_connection_string = acs_connection_string
         self.acs_callback_path = acs_callback_path
+        self.media_streaming_configuration = MediaStreamingOptions(
+            transport_url=acs_media_streaming_websocker_path,
+            transport_type=MediaStreamingTransportType.WEBSOCKET,
+            content_type=MediaStreamingContentType.AUDIO,
+            audio_channel_type=MediaStreamingAudioChannelType.MIXED,
+            start_media_streaming=True,
+            enable_bidirectional=True,
+            audio_format=AudioFormat.PCM24_K_MONO
+        )
     
     async def call(self, target_number: str):
         self.call_automation_client = CallAutomationClient.from_connection_string(self.acs_connection_string)
         self.target_participant = PhoneNumberIdentifier(target_number)
         self.source_caller = PhoneNumberIdentifier(self.source_number)
-        call_connection_properties = self.call_automation_client.create_call(self.target_participant, 
-                                                                    self.acs_callback_path,
-                                                                    source_caller_id_number=self.source_caller)
+        self.call_automation_client.create_call(
+            self.target_participant, 
+            self.acs_callback_path,
+            media_streaming=self.media_streaming_configuration,
+            source_caller_id_number=self.source_caller
+        )
 
     async def _outbound_call_handler(self, request):
         print("Outbound call handler")
@@ -44,7 +62,7 @@ class OutboundCall:
             # Parsing callback events
             event = CloudEvent.from_dict(event_dict)
             call_connection_id = event.data['callConnectionId']
-            print("%s event received for call connection id: %s", event.type, call_connection_id)
+            print(f"{event.type} event received for call connection id: {call_connection_id}")
             call_connection_client = self.call_automation_client.get_call_connection(call_connection_id)
             # target_participant = PhoneNumberIdentifier(self.target_number)
             if event.type == "Microsoft.Communication.CallConnected":

--- a/src/app/acs/caller.py
+++ b/src/app/acs/caller.py
@@ -48,7 +48,7 @@ class OutboundCall:
         self.target_participant = PhoneNumberIdentifier(target_number)
         self.source_caller = PhoneNumberIdentifier(self.source_number)
 
-        websocket_url = 'wss://' + self.acs_callback_path + '/realtime'
+        websocket_url = 'wss://' + self.acs_callback_path + '/realtime-acs'
 
         media_streaming_options = MediaStreamingOptions(
                         transport_url=websocket_url,

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -53,12 +53,10 @@ async def create_app():
 
     rtmt = RTMiddleTier(llm_endpoint, llm_deployment, llm_credential)
 
-    if (os.environ.get("ACS_TARGET_NUMBER") is not None and
-            os.environ.get("ACS_SOURCE_NUMBER") is not None and
+    if (os.environ.get("ACS_SOURCE_NUMBER") is not None and
             os.environ.get("ACS_CONNECTION_STRING") is not None and
             os.environ.get("ACS_CALLBACK_PATH") is not None):
         caller = OutboundCall(
-            os.environ.get("ACS_TARGET_NUMBER"),
             os.environ.get("ACS_SOURCE_NUMBER"),
             os.environ.get("ACS_CONNECTION_STRING"),
             os.environ.get("ACS_CALLBACK_PATH"),
@@ -117,8 +115,10 @@ async def create_app():
         return web.FileResponse(static_directory / 'index.html')
 
     async def call(request):
+        body = await request.json()
+
         if (caller is not None):
-            await caller.call()
+            await caller.call(body['number'])
             return web.Response(text="Created outbound call")
         else:
             return web.Response(text="Outbound calling is not configured")

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -55,11 +55,13 @@ async def create_app():
 
     if (os.environ.get("ACS_SOURCE_NUMBER") is not None and
             os.environ.get("ACS_CONNECTION_STRING") is not None and
-            os.environ.get("ACS_CALLBACK_PATH") is not None):
+            os.environ.get("ACS_CALLBACK_PATH") is not None and
+            os.environ.get("ACS_MEDIA_STREAMING_WEBSOCKET_PATH") is not None):
         caller = OutboundCall(
             os.environ.get("ACS_SOURCE_NUMBER"),
             os.environ.get("ACS_CONNECTION_STRING"),
             os.environ.get("ACS_CALLBACK_PATH"),
+            os.environ.get("ACS_MEDIA_STREAMING_WEBSOCKET_PATH")
         )
         caller.attach_to_app(app, "/acs")
 

--- a/src/app/backend/rtmt.py
+++ b/src/app/backend/rtmt.py
@@ -3,7 +3,7 @@ import asyncio
 import json
 from enum import Enum
 from typing import Any, Callable, Optional
-from aiohttp import web
+from aiohttp import WSMessage, web
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from azure.core.credentials import AzureKeyCredential
 
@@ -69,7 +69,87 @@ class RTMiddleTier:
             self._token_provider = get_bearer_token_provider(credentials, "https://cognitiveservices.azure.com/.default")
             self._token_provider() # Warm up during startup so we have a token cached when the first request arrives
 
-    async def _process_message_to_client(self, msg: str, client_ws: web.WebSocketResponse, server_ws: web.WebSocketResponse) -> Optional[str]:
+    def _acs_message_to_openai(self, msg_data_json: str) -> Optional[str]:
+        """
+        Transforms websocket message data from Azure Communication Services (ACS) to the OpenAI Realtime API format.
+        Args:
+            msg_data_json (str): The JSON string containing the ACS message data.
+        Returns:
+            Optional[str]: The transformed message in the OpenAI Realtime API format, or None if the message kind is not recognized.
+        This is needed to plug the Azure Communication Services audio stream into the OpenAI Realtime API.
+        Both APIs have different message formats, so this function acts as a bridge between them.
+        This method decides, if the given message is relevant for the OpenAI Realtime API, and if so, it is transformed to the OpenAI Realtime API format.        
+        """
+        message = json.loads(msg_data_json)
+        updated_message = msg_data_json
+
+        # Initial message from Azure Communication Services.
+        # Set the initial configuration for the OpenAI Realtime API by sending a session.update message.
+        if message["kind"] == "AudioMetadata":
+            oai_message = {
+                "type": "session.update",
+                "session": {
+                    "tool_choice": "auto" if len(self.tools) > 0 else "none",
+                    "tools": [tool.schema for tool in self.tools.values()],
+                    "turn_detection": {
+                        "type": 'server_vad',
+                        "threshold": 0.7, # Adjust if necessary
+                        "prefix_padding_ms": 300, # Adjust if necessary
+                        "silence_duration_ms": 500 # Adjust if necessary
+                    },
+                }
+            }
+
+            if self.system_message is not None:
+                oai_message["session"]["instructions"] = self.system_message
+            if self.temperature is not None:
+                oai_message["session"]["temperature"] = self.temperature
+            if self.max_tokens is not None:
+                oai_message["session"]["max_response_output_tokens"] = self.max_tokens
+            if self.disable_audio is not None:
+                oai_message["session"]["disable_audio"] = self.disable_audio
+                
+            updated_message = json.dumps(oai_message)
+        
+        # Message from Azure Communication Services with audio data.                    
+        # Transform the message to the OpenAI Realtime API format.
+        elif message["kind"] == "AudioData":
+            oai_message = {
+                "type": "input_audio_buffer.append",
+                "audio": message["audioData"]["data"]
+            }
+            updated_message = json.dumps(oai_message)
+            
+        return updated_message
+
+    def _openai_message_to_acs(self, msg_data_json: str) -> Optional[str]:
+        """
+        Transforms websocket message data from the OpenAI Realtime API format into the Azure Communication Services (ACS) format.
+        Args:
+            msg_data_json (str): The JSON string containing the message data from the OpenAI Realtime API.
+        Returns:
+            Optional[str]: A JSON string containing the transformed message in ACS format, or None if the message type is not handled.
+        This is needed to plug the OpenAI Realtime API audio stream into Azure Communication Services.
+        Both APIs have different message formats, so this function acts as a bridge between them.
+        This method decides, if the given message is relevant for the ACS, and if so, it is transformed to the ACS format.   
+        """
+        message = json.loads(msg_data_json)
+        updated_message = None
+        
+        # Message from the OpenAI Realtime API with audio data.
+        # Transform the message to the Azure Communication Services format.
+        if message["type"] == "response.audio.delta":            
+            acs_message = {
+                "kind": "AudioData",
+                "audioData": {
+                    "data": message["delta"]
+                }
+            }
+            updated_message = json.dumps(acs_message)            
+
+        return updated_message
+
+    async def _process_message_to_client(self, msg: WSMessage, client_ws: web.WebSocketResponse, server_ws: web.WebSocketResponse, is_acs_audio_stream: bool) -> Optional[str]:
         message = json.loads(msg.data)
         updated_message = msg.data
         if message is not None:
@@ -119,14 +199,16 @@ class RTMiddleTier:
                             }
                         })
                         if result.destination == ToolResultDirection.TO_CLIENT:
-                            # TODO: this will break clients that don't know about this extra message, rewrite
-                            # this to be a regular text message with a special marker of some sort
-                            await client_ws.send_json({
-                                "type": "extension.middle_tier_tool_response",
-                                "previous_item_id": tool_call.previous_id,
-                                "tool_name": item["name"],
-                                "tool_result": result.to_text()
-                            })
+                            # Only send extra messages to clients that are not ACS audio streams
+                            if is_acs_audio_stream == False:
+                                # TODO: this will break clients that don't know about this extra message, rewrite
+                                # this to be a regular text message with a special marker of some sort
+                                await client_ws.send_json({
+                                    "type": "extension.middle_tier_tool_response",
+                                    "previous_item_id": tool_call.previous_id,
+                                    "tool_name": item["name"],
+                                    "tool_result": result.to_text()
+                                })
                         updated_message = None
 
                 case "response.done":
@@ -137,18 +219,32 @@ class RTMiddleTier:
                         })
                     if "response" in message:
                         replace = False
-                        for i, output in enumerate(reversed(message["response"]["output"])):
+                        outputs = message["response"]["output"]
+                        for output in reversed(outputs):
                             if output["type"] == "function_call":
-                                message["response"]["output"].pop(i)
+                                outputs.remove(output)
                                 replace = True
                         if replace:
                             updated_message = json.dumps(message)
 
+        # Transform the message to the Azure Communication Services format,
+        # if it comes from the OpenAI realtime stream.
+        if is_acs_audio_stream and updated_message is not None:
+            updated_message = self._openai_message_to_acs(updated_message)
+
         return updated_message
 
-    async def _process_message_to_server(self, msg: str, ws: web.WebSocketResponse) -> Optional[str]:
+    async def _process_message_to_server(self, msg: WSMessage, ws: web.WebSocketResponse, is_acs_audio_stream) -> Optional[str]:
         message = json.loads(msg.data)
         updated_message = msg.data
+
+        # Transform the message to the OpenAI Realtime API format first,
+        # if it comes from the Azure Communication Services audio stream.
+        if (is_acs_audio_stream):
+            data = self._acs_message_to_openai(msg.data)
+            message = json.loads(data)
+            updated_message = data
+
         if message is not None:
             match message["type"]:
                 case "session.update":
@@ -168,7 +264,7 @@ class RTMiddleTier:
 
         return updated_message
 
-    async def _forward_messages(self, ws: web.WebSocketResponse):
+    async def _forward_messages(self, ws: web.WebSocketResponse, is_acs_audio_stream: bool):
         async with aiohttp.ClientSession(base_url=self.endpoint) as session:
             params = { "api-version": "2024-10-01-preview", "deployment": self.deployment }
             headers = {}
@@ -182,7 +278,7 @@ class RTMiddleTier:
                 async def from_client_to_server():
                     async for msg in ws:
                         if msg.type == aiohttp.WSMsgType.TEXT:
-                            new_msg = await self._process_message_to_server(msg, ws)
+                            new_msg = await self._process_message_to_server(msg, ws, is_acs_audio_stream)
                             if new_msg is not None:
                                 await target_ws.send_str(new_msg)
                         else:
@@ -191,7 +287,7 @@ class RTMiddleTier:
                 async def from_server_to_client():
                     async for msg in target_ws:
                         if msg.type == aiohttp.WSMsgType.TEXT:
-                            new_msg = await self._process_message_to_client(msg, ws, target_ws)
+                            new_msg = await self._process_message_to_client(msg, ws, target_ws, is_acs_audio_stream)
                             if new_msg is not None:
                                 await ws.send_str(new_msg)
                         else:
@@ -206,8 +302,15 @@ class RTMiddleTier:
     async def _websocket_handler(self, request: web.Request):
         ws = web.WebSocketResponse()
         await ws.prepare(request)
-        await self._forward_messages(ws)
+        await self._forward_messages(ws, False)
+        return ws
+    
+    async def _websocket_handler_acs(self, request: web.Request):
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        await self._forward_messages(ws, True)
         return ws
 
     def attach_to_app(self, app, path):
         app.router.add_get(path, self._websocket_handler)
+        app.router.add_get(path + "-acs", self._websocket_handler_acs)

--- a/src/app/static/app.js
+++ b/src/app/static/app.js
@@ -139,18 +139,16 @@ function onToggleListening() {
 
 function onCallButton() {
     const phonenumber = document.getElementById('phonenumber').value;
-
-    const callDetails = {
-        number: phonenumber
-    };
-
-
-    theUrl = window.location.href + "call";
-    var xmlHttp = new XMLHttpRequest();
-    xmlHttp.open( "POST", theUrl, false );
-    xmlHttp.send( callDetails );
     
-    reportDiv.textContent = xmlHttp.responseText;   
+    theUrl = window.location.href + "call";
+    fetch(theUrl, {
+        method : "POST",
+        body : JSON.stringify({
+            number: phonenumber
+        })
+    })
+    .then(response => reportDiv.textContent = response.json())
+    .catch(error => console.error('Error:', error));
 }
 
 toggleButton.addEventListener('click', onToggleListening);

--- a/src/app/static/app.js
+++ b/src/app/static/app.js
@@ -139,13 +139,14 @@ function onToggleListening() {
 
 function onCallButton() {
     const phonenumber = document.getElementById('phonenumber').value;
-    
+    const callDetails = {
+        number: phonenumber
+    };
+
     theUrl = window.location.href + "call";
     fetch(theUrl, {
         method : "POST",
-        body : JSON.stringify({
-            number: phonenumber
-        })
+        body : JSON.stringify(callDetails)
     })
     .then(response => reportDiv.textContent = response.json())
     .catch(error => console.error('Error:', error));


### PR DESCRIPTION
This pull request adds Azure Communication Services (ACS) integration and the handling of WebSocket messages in the application. The changes enhance the functionality and robustness of the ACS integration and improve the transformation of messages between ACS and the OpenAI Realtime API.

As the message format for ACS and OpenAI realtime are quite different, they need to be "translated" between each other.

For this, this PR

- Introcdues a dedicated `/realtime-acr` endpoint in `rtmt.py` (to ensure messages to through the translation logic)
- Introduces translation logic methods between ACS and OpenAI in `rtmt.py`